### PR TITLE
Add a json / json5 / hjson parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.bak
+.*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.bak
 .*.swp
+private/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ serde = "1.0"
 once_cell = "1.12"
 annotate_derive = {path = "annotate_derive"}
 inventory = "0.2"
+pest = "2.2"
+pest_derive = "2.2"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/examples/data/basic1.json5
+++ b/examples/data/basic1.json5
@@ -1,0 +1,17 @@
+{
+    // Comment before "a".
+    "a": "This is a test",
+    // "b" is a bareword.
+    b: 12345,
+    // A hex constant
+    c: 0x1234,
+    d: [
+        // A true value
+        true,
+        // A false value
+        false,
+        "other", // other
+        "extra"
+        // extra comment
+    ]
+}

--- a/examples/data/basic2.json5
+++ b/examples/data/basic2.json5
@@ -1,0 +1,11 @@
+// Leading comment
+{
+    // Comment before "a".
+    "a": "This is a test",
+    // "b" is a bareword.
+    b: 12345,
+    // A hex constant
+    c: 0x1234, //eol
+    d: [],
+}
+// Post-object trailing comment.

--- a/examples/data/basic3.json5
+++ b/examples/data/basic3.json5
@@ -1,0 +1,11 @@
+// Leading comment
+{
+    // Comment before "a".
+    "a": "This is a test",
+    // "b" is a bareword.
+    b: 12345,
+    // A hex constant
+    c: 0x1234
+    // In-object Trailing comment
+}
+// Post-object trailing comment.

--- a/examples/data/basic4.json5
+++ b/examples/data/basic4.json5
@@ -1,0 +1,13 @@
+// Leading comment
+{
+    // Comment before "a".
+    "a": "This is a test",
+    // "b" is a bareword.
+    b: 12345,
+    // A hex constant
+    c: 0x1234, //eol
+    d: [
+        // An empty list
+    ],
+}
+// Post-object trailing comment.

--- a/examples/transcode.rs
+++ b/examples/transcode.rs
@@ -1,0 +1,66 @@
+use anyhow::{anyhow, Result};
+use clap::{ArgEnum, Parser};
+use serde_annotate::{ColorProfile, Document};
+use std::path::PathBuf;
+
+#[derive(ArgEnum, Clone, Copy, Debug)]
+enum Format {
+    Json,
+    Json5,
+    Hjson,
+    Yaml,
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(short, long, arg_enum, value_parser)]
+    format: Format,
+
+    #[clap(short, long, value_parser)]
+    color: bool,
+
+    #[clap(name = "FILE")]
+    file: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let text = std::fs::read_to_string(&args.file)?;
+    let document = Document::parse(&text)?;
+
+    let profile = ColorProfile::basic();
+    let s = match args.format {
+        Format::Json => {
+            let mut d = document.to_json();
+            if args.color {
+                d = d.color(profile);
+            }
+            d.to_string()
+        }
+        Format::Json5 => {
+            let mut d = document.to_json5();
+            if args.color {
+                d = d.color(profile);
+            }
+            d.to_string()
+        }
+        Format::Hjson => {
+            let mut d = document.to_hjson();
+            if args.color {
+                d = d.color(profile);
+            }
+            d.to_string()
+        }
+        Format::Yaml => {
+            let mut d = document.to_yaml();
+            if args.color {
+                d = d.color(profile);
+            }
+            d.to_string()
+        }
+    };
+
+    println!("{}", s);
+    Ok(())
+}

--- a/examples/transcode.rs
+++ b/examples/transcode.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::{ArgEnum, Parser};
 use serde_annotate::{ColorProfile, Document};
 use std::path::PathBuf;

--- a/private/test_all_ot_hjson.sh
+++ b/private/test_all_ot_hjson.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# There are _lots_ of hjson files in https://github.com/lowRISC/opentitan/
+# This script times the transcoding of all of them.
+set -euo pipefail
+: "${REPO_TOP:=$(git rev-parse --show-toplevel)}"
+: "${OPENTITAN:=${HOME}/opentitan/opentitan}"
+: "${PROFILE:=dev}"
+
+cd ${REPO_TOP}
+ARGS=("$@")
+if [[ ${#ARGS[@]} == 0 ]]; then
+    ARGS=($(find ${OPENTITAN} -name "*.hjson" -o -name "*.json"))
+fi
+
+case ${PROFILE} in
+    release)
+        TARGET=target/release
+        ;;
+    *)
+        TARGET=target/debug
+        ;;
+esac
+
+rm -f /tmp/transcode.txt
+cargo build --profile=${PROFILE} --example transcode
+for f in ${ARGS[@]}; do
+    echo "===== Testing $f ====="
+    /usr/bin/time -f "%C %U" -a -o /tmp/transcode.txt ${TARGET}/examples/transcode --color --format hjson $f
+done
+
+cat /tmp/transcode.txt | cut -d' ' -f5- | sort -n -k2 >/tmp/transcode.$$.txt

--- a/src/document.rs
+++ b/src/document.rs
@@ -6,19 +6,28 @@ use crate::integer::Int;
 use crate::relax::Relax;
 
 /// Represents possible serialized string formats.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum StrFormat {
     /// The standard format for the serialization backend.
     Standard,
     /// Always quote the string, even if not required by the backend.
     Quoted,
+    /// Render the string unquoted if allowed by the backend.
+    Unquoted,
     /// Format the string as a multiline block, if allowed by the backend.
     Multiline,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum CommentFormat {
-    Normal,
+    /// The standard format for the serialization backend.
+    Standard,
+    /// Render comments in block form if allowed by the backend.
+    Block,
+    /// Render comments in single-line hash form if allowed by the backend.
+    Hash,
+    /// Render comments in single-line slash-slash form if allowed by the backend.
+    SlashSlash,
 }
 
 #[derive(Clone, Debug)]

--- a/src/document.rs
+++ b/src/document.rs
@@ -71,6 +71,19 @@ impl Document {
         relax.from_str(text)
     }
 
+    pub fn from_json(text: &str) -> Result<Document, Error> {
+        let relax = Relax::json();
+        relax.from_str(text)
+    }
+    pub fn from_json5(text: &str) -> Result<Document, Error> {
+        let relax = Relax::json5();
+        relax.from_str(text)
+    }
+    pub fn from_hjson(text: &str) -> Result<Document, Error> {
+        let relax = Relax::hjson();
+        relax.from_str(text)
+    }
+
     pub fn variant(&self) -> &'static str {
         match self {
             Document::Comment(_, _) => "Comment",

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     FmtError(std::fmt::Error),
     #[error("Type {0:?} is not valid as a mapping key")]
     KeyTypeError(&'static str),
+    #[error("document structure error: expected {0} but got {1}")]
+    StructureError(&'static str, &'static str),
 }
 
 impl ser::Error for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::relax::ParseError;
 use serde::ser;
 use std::fmt::Display;
 use thiserror::Error;
@@ -6,12 +7,14 @@ use thiserror::Error;
 pub enum Error {
     #[error("serializer error: {0}")]
     Ser(String),
-    #[error("unknown error")]
-    Unknown,
+    #[error("unknown error: {0}")]
+    Unknown(String),
     #[error("formatter error: {0:?}")]
     FmtError(std::fmt::Error),
     #[error("Type {0:?} is not valid as a mapping key")]
     KeyTypeError(&'static str),
+    #[error(transparent)]
+    ParseError(#[from] ParseError),
     #[error("document structure error: expected {0} but got {1}")]
     StructureError(&'static str, &'static str),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     ParseError(#[from] ParseError),
     #[error("document structure error: expected {0} but got {1}")]
     StructureError(&'static str, &'static str),
+    #[error("syntax error: {0}")]
+    SyntaxError(String),
 }
 
 impl ser::Error for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,8 @@ pub enum Error {
     ParseError(#[from] ParseError),
     #[error("document structure error: expected {0} but got {1}")]
     StructureError(&'static str, &'static str),
-    #[error("syntax error: {0}")]
-    SyntaxError(String),
+    #[error("syntax error: {0} at {1}:{2}\n| {3}\n| {4:>2$}")]
+    SyntaxError(String, usize, usize, String, &'static str),
 }
 
 impl ser::Error for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use crate::relax::ParseError;
 use serde::ser;
+use std::char::CharTryFromError;
 use std::fmt::Display;
 use thiserror::Error;
 
@@ -9,12 +10,16 @@ pub enum Error {
     Ser(String),
     #[error("unknown error: {0}")]
     Unknown(String),
+    #[error("unhandled escape: `\\{0}`")]
+    EscapeError(char),
     #[error("formatter error: {0:?}")]
     FmtError(std::fmt::Error),
     #[error("Type {0:?} is not valid as a mapping key")]
     KeyTypeError(&'static str),
     #[error(transparent)]
     ParseError(#[from] ParseError),
+    #[error(transparent)]
+    CharTryFromError(#[from] CharTryFromError),
     #[error("document structure error: expected {0} but got {1}")]
     StructureError(&'static str, &'static str),
     #[error("syntax error: {0} at {1}:{2}\n| {3}\n| {4:>2$}")]

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -25,7 +25,7 @@ pub enum IntValue {
     I128(i128),
 }
 
-macro_rules! impl_from {
+macro_rules! impl_from_primitive {
     ($t:ty, $f:ident) => {
         impl From<$t> for IntValue {
             fn from(val: $t) -> Self {
@@ -35,16 +35,16 @@ macro_rules! impl_from {
     };
 }
 
-impl_from!(u8, U8);
-impl_from!(u16, U16);
-impl_from!(u32, U32);
-impl_from!(u64, U64);
-impl_from!(u128, U128);
-impl_from!(i8, I8);
-impl_from!(i16, I16);
-impl_from!(i32, I32);
-impl_from!(i64, I64);
-impl_from!(i128, I128);
+impl_from_primitive!(u8, U8);
+impl_from_primitive!(u16, U16);
+impl_from_primitive!(u32, U32);
+impl_from_primitive!(u64, U64);
+impl_from_primitive!(u128, U128);
+impl_from_primitive!(i8, I8);
+impl_from_primitive!(i16, I16);
+impl_from_primitive!(i32, I32);
+impl_from_primitive!(i64, I64);
+impl_from_primitive!(i128, I128);
 
 impl IntValue {
     const HEX: &'static [u8; 16] = b"0123456789ABCDEF";
@@ -166,6 +166,38 @@ impl fmt::Display for Int {
         write!(f, "{}", self.format(Some(&self.base)))
     }
 }
+
+macro_rules! impl_from_int {
+    ($t:ty) => {
+        impl From<Int> for $t {
+            fn from(val: Int) -> Self {
+                match val.value {
+                    IntValue::U8(v) => v as $t,
+                    IntValue::U16(v) => v as $t,
+                    IntValue::U32(v) => v as $t,
+                    IntValue::U64(v) => v as $t,
+                    IntValue::U128(v) => v as $t,
+                    IntValue::I8(v) => v as $t,
+                    IntValue::I16(v) => v as $t,
+                    IntValue::I32(v) => v as $t,
+                    IntValue::I64(v) => v as $t,
+                    IntValue::I128(v) => v as $t,
+                }
+            }
+        }
+    };
+}
+
+impl_from_int!(u8);
+impl_from_int!(u16);
+impl_from_int!(u32);
+impl_from_int!(u64);
+impl_from_int!(u128);
+impl_from_int!(i8);
+impl_from_int!(i16);
+impl_from_int!(i32);
+impl_from_int!(i64);
+impl_from_int!(i128);
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod document;
 mod error;
 mod integer;
 mod json;
+mod relax;
 mod ser;
 mod yaml;
 

--- a/src/relax.pest
+++ b/src/relax.pest
@@ -1,0 +1,123 @@
+// see https://spec.json5.org/#syntactic-grammar and
+// https://spec.json5.org/#lexical-grammar
+
+COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" | "//" ~ (!line_terminator ~ ANY)* }
+
+WHITESPACE = _{
+  "\u{0009}" |
+  "\u{000B}" |
+  "\u{000C}" |
+  "\u{0020}" |
+  "\u{00A0}" |
+  "\u{FEFF}" |
+  SPACE_SEPARATOR |
+  line_terminator
+}
+
+array = { "[" ~ "]" | "[" ~ value ~ ("," ~ value)* ~ ","? ~ "]" }
+
+boolean = @{ "true" | "false" }
+
+char_escape_sequence = @{ single_escape_char | non_escape_char }
+
+char_literal = @{ !("\\" | line_terminator) ~ ANY }
+
+decimal_integer_literal = _{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+
+decimal_literal = _{
+  decimal_integer_literal ~ "." ~ ASCII_DIGIT* ~ exponent_part? |
+  "." ~ ASCII_DIGIT+~ exponent_part? |
+  decimal_integer_literal ~ exponent_part?
+}
+
+double_quote_char = _{
+  "\\" ~ escape_sequence |
+  line_continuation |
+  !"\"" ~ char_literal
+}
+
+escape_char = _{ single_escape_char | ASCII_DIGIT | "x" | "u" }
+
+escape_sequence = _{
+  char_escape_sequence |
+  nul_escape_sequence |
+  "x" ~ hex_escape_sequence |
+  "u" ~ unicode_escape_sequence
+}
+
+exponent_part = _{ ^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+ }
+
+hex_escape_sequence = @{ ASCII_HEX_DIGIT{2} }
+
+hex_integer_literal = _{ ^"0x" ~ ASCII_HEX_DIGIT+ }
+
+identifier = ${ identifier_start ~ identifier_part* }
+
+identifier_part = _{
+  identifier_start |
+  &(
+    NONSPACING_MARK |
+    DIACRITIC | // not sure about this, spec says "Combining spacing mark (Mc)"
+    DECIMAL_NUMBER |
+    CONNECTOR_PUNCTUATION |
+    "\u{200C}" |
+    "\u{200D}"
+  ) ~ char_literal
+}
+
+identifier_start = _{
+  &(unicode_letter | "$" | "_") ~ char_literal |
+  "\\u" ~ unicode_escape_sequence
+}
+
+key = _{ identifier | string }
+
+line_continuation = _{ "\\" ~ line_terminator_sequence }
+
+line_terminator = _{ "\u{000A}" | "\u{000D}" | "\u{2028}" | "\u{2029}" }
+
+line_terminator_sequence = _{ "\u{000D}" ~ "\u{000A}" | line_terminator }
+
+non_escape_char = _{ !(escape_char | line_terminator) ~ ANY }
+
+nul_escape_sequence = @{ "0" }
+
+null = @{ "null" }
+
+number = @{ ("+" | "-")? ~ numeric_literal }
+
+numeric_literal = _{
+  hex_integer_literal |
+  decimal_literal |
+  "Infinity" |
+  "NaN"
+}
+
+object = { "{" ~ "}" | "{" ~ pair ~ ("," ~ pair)* ~ ","? ~ "}" }
+
+pair = _{ key ~ ":" ~ value }
+
+single_escape_char = _{ "'" | "\"" | "\\" | "b" | "f" | "n" | "r" | "t" | "v" }
+
+single_quote_char = _{
+  "\\" ~ escape_sequence |
+  line_continuation |
+  !"'" ~ char_literal
+}
+
+string = ${ "\"" ~ double_quote_char* ~ "\"" | "'" ~ single_quote_char* ~ "'" }
+
+text = _{ SOI ~ value ~ EOI }
+
+unicode_escape_sequence = @{ ASCII_HEX_DIGIT{4} }
+
+unicode_letter = _{
+  UPPERCASE_LETTER |
+  LOWERCASE_LETTER |
+  TITLECASE_LETTER |
+  MODIFIER_LETTER |
+  OTHER_LETTER |
+  LETTER_NUMBER
+}
+
+value = _{ null | boolean | string | number | object | array }

--- a/src/relax.pest
+++ b/src/relax.pest
@@ -2,12 +2,21 @@
 // https://spec.json5.org/#lexical-grammar
 
 //COMMENT = { "/*" ~ (!"*/" ~ ANY)* ~ "*/" | "//" ~ (!line_terminator ~ ANY)* }
-COMMENT = { block_comment | slash_comments+ | slash_comment }
+COMMENT = { block_comment | slash_comments | hash_comments }
 
 block_comment = { "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 slash_comment = { "//" ~ (!line_terminator ~ ANY)* }
 slash_eol = @{ slash_comment ~ line_terminator_sequence ~ WHITESPACE*}
-slash_comments = { slash_eol ~ (slash_eol | slash_comment)+ }
+slash_comments = { 
+    slash_eol ~ (slash_eol | slash_comment)+ |
+    slash_comment
+}
+hash_comment = { "#" ~ (!line_terminator ~ ANY)* }
+hash_eol = @{ hash_comment ~ line_terminator_sequence ~ WHITESPACE*}
+hash_comments = { 
+    hash_eol ~ (hash_eol | hash_comment)+ |
+    hash_comment
+}
 
 WHITESPACE = _{
   "\u{0009}" |
@@ -113,7 +122,7 @@ single_quote_char = _{
 
 string = ${ "\"" ~ double_quote_char* ~ "\"" | "'" ~ single_quote_char* ~ "'" }
 
-text = { SOI ~ value ~ EOI }
+text = { SOI ~ value? ~ EOI }
 
 unicode_escape_sequence = @{ ASCII_HEX_DIGIT{4} }
 

--- a/src/relax.pest
+++ b/src/relax.pest
@@ -1,7 +1,6 @@
 // see https://spec.json5.org/#syntactic-grammar and
 // https://spec.json5.org/#lexical-grammar
 
-//COMMENT = { "/*" ~ (!"*/" ~ ANY)* ~ "*/" | "//" ~ (!line_terminator ~ ANY)* }
 COMMENT = { block_comment | slash_comments | hash_comments }
 
 block_comment = { "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
@@ -29,7 +28,9 @@ WHITESPACE = _{
   line_terminator
 }
 
-array = { "[" ~ "]" | "[" ~ value ~ ("," ~ value)* ~ ","? ~ "]" }
+comma = {","}
+
+array = { "[" ~ (value ~ comma?)* ~ "]" }
 
 boolean = @{ "true" | "false" }
 

--- a/src/relax.pest
+++ b/src/relax.pest
@@ -109,7 +109,7 @@ numeric_literal = _{
   "NaN"
 }
 
-object = { "{" ~ "}" | "{" ~ kvpair ~ ("," ~ kvpair)* ~ ","? ~ "}" }
+object = { "{" ~ (kvpair ~ comma?)* ~ "}" }
 
 kvpair = _{ key ~ ":" ~ value }
 

--- a/src/relax.pest
+++ b/src/relax.pest
@@ -69,14 +69,12 @@ hex_integer_literal = _{ ^"0x" ~ ASCII_HEX_DIGIT+ }
 bin_integer_literal = _{ ^"0b" ~ ('0'..'1')+ }
 oct_integer_literal = _{ ^"0o" ~ ('0'..'7')+ }
 
-hjson_punctuator = { "{" | "}" | "[" | "]" | "," | ":" | "/*" | "//" | "#" }
-hjson_unquoted_string = @{ !hjson_punctuator ~ (!line_terminator ~ ANY)+ }
-
 identifier = ${ identifier_start ~ identifier_part* }
 
 identifier_part = _{
   identifier_start |
   &(
+    !hjson_punctuator |
     NONSPACING_MARK |
     DIACRITIC | // not sure about this, spec says "Combining spacing mark (Mc)"
     DECIMAL_NUMBER |
@@ -91,7 +89,8 @@ identifier_start = _{
   "\\u" ~ unicode_escape_sequence
 }
 
-key = _{ identifier | string }
+
+key = _{ identifier | number | string }
 
 line_continuation = _{ "\\" ~ line_terminator_sequence }
 
@@ -130,7 +129,13 @@ single_quote_char = _{
 
 hjson_multiline_string = @{ "'''" ~ (!"'''" ~ ANY)* ~ "'''" }
 
-string = ${
+hjson_punctuator = { "{" | "}" | "[" | "]" | "," | ":" }
+hjson_number = { number ~ (hjson_punctuator | WHITESPACE | COMMENT) }
+hjson_key = @{ (!hjson_punctuator ~ !COMMENT ~ ANY)+ }
+hjson_unquoted = @{ !hjson_number ~ !hjson_punctuator ~ !COMMENT ~ (!line_terminator ~ ANY)+ }
+hjson_unquoted_string = @{ hjson_unquoted ~ line_terminator_sequence ~ WHITESPACE* }
+
+string = @{
     hjson_multiline_string |
     "'" ~ single_quote_char* ~ "'" |
     "\"" ~ double_quote_char* ~ "\"" |
@@ -150,4 +155,4 @@ unicode_letter = _{
   LETTER_NUMBER
 }
 
-value = _{ null | boolean | number | object | array | string }
+value = _{ null | boolean | string | number | object | array }

--- a/src/relax.pest
+++ b/src/relax.pest
@@ -1,7 +1,13 @@
 // see https://spec.json5.org/#syntactic-grammar and
 // https://spec.json5.org/#lexical-grammar
 
-COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" | "//" ~ (!line_terminator ~ ANY)* }
+//COMMENT = { "/*" ~ (!"*/" ~ ANY)* ~ "*/" | "//" ~ (!line_terminator ~ ANY)* }
+COMMENT = { block_comment | slash_comments+ | slash_comment }
+
+block_comment = { "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
+slash_comment = { "//" ~ (!line_terminator ~ ANY)* }
+slash_eol = @{ slash_comment ~ line_terminator_sequence ~ WHITESPACE*}
+slash_comments = { slash_eol ~ (slash_eol | slash_comment)+ }
 
 WHITESPACE = _{
   "\u{0009}" |
@@ -93,9 +99,9 @@ numeric_literal = _{
   "NaN"
 }
 
-object = { "{" ~ "}" | "{" ~ pair ~ ("," ~ pair)* ~ ","? ~ "}" }
+object = { "{" ~ "}" | "{" ~ kvpair ~ ("," ~ kvpair)* ~ ","? ~ "}" }
 
-pair = _{ key ~ ":" ~ value }
+kvpair = _{ key ~ ":" ~ value }
 
 single_escape_char = _{ "'" | "\"" | "\\" | "b" | "f" | "n" | "r" | "t" | "v" }
 
@@ -107,7 +113,7 @@ single_quote_char = _{
 
 string = ${ "\"" ~ double_quote_char* ~ "\"" | "'" ~ single_quote_char* ~ "'" }
 
-text = _{ SOI ~ value ~ EOI }
+text = { SOI ~ value ~ EOI }
 
 unicode_escape_sequence = @{ ASCII_HEX_DIGIT{4} }
 

--- a/src/relax.pest
+++ b/src/relax.pest
@@ -66,6 +66,8 @@ exponent_part = _{ ^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+ }
 hex_escape_sequence = @{ ASCII_HEX_DIGIT{2} }
 
 hex_integer_literal = _{ ^"0x" ~ ASCII_HEX_DIGIT+ }
+bin_integer_literal = _{ ^"0b" ~ ('0'..'1')+ }
+oct_integer_literal = _{ ^"0o" ~ ('0'..'7')+ }
 
 hjson_punctuator = { "{" | "}" | "[" | "]" | "," | ":" | "/*" | "//" | "#" }
 hjson_unquoted_string = @{ !hjson_punctuator ~ (!line_terminator ~ ANY)+ }
@@ -106,7 +108,9 @@ null = @{ "null" }
 number = @{ ("+" | "-")? ~ numeric_literal }
 
 numeric_literal = _{
+  bin_integer_literal |
   hex_integer_literal |
+  oct_integer_literal |
   decimal_literal |
   "Infinity" |
   "NaN"

--- a/src/relax.pest
+++ b/src/relax.pest
@@ -67,6 +67,9 @@ hex_escape_sequence = @{ ASCII_HEX_DIGIT{2} }
 
 hex_integer_literal = _{ ^"0x" ~ ASCII_HEX_DIGIT+ }
 
+hjson_punctuator = { "{" | "}" | "[" | "]" | "," | ":" | "/*" | "//" | "#" }
+hjson_unquoted_string = @{ !hjson_punctuator ~ (!line_terminator ~ ANY)+ }
+
 identifier = ${ identifier_start ~ identifier_part* }
 
 identifier_part = _{
@@ -121,7 +124,14 @@ single_quote_char = _{
   !"'" ~ char_literal
 }
 
-string = ${ "\"" ~ double_quote_char* ~ "\"" | "'" ~ single_quote_char* ~ "'" }
+hjson_multiline_string = @{ "'''" ~ (!"'''" ~ ANY)* ~ "'''" }
+
+string = ${
+    hjson_multiline_string |
+    "'" ~ single_quote_char* ~ "'" |
+    "\"" ~ double_quote_char* ~ "\"" |
+    hjson_unquoted_string
+}
 
 text = { SOI ~ value? ~ EOI }
 
@@ -136,4 +146,4 @@ unicode_letter = _{
   LETTER_NUMBER
 }
 
-value = _{ null | boolean | string | number | object | array }
+value = _{ null | boolean | number | object | array | string }

--- a/src/relax.rs
+++ b/src/relax.rs
@@ -1,0 +1,440 @@
+use pest::error::Error as PestError;
+use pest::iterators::{Pair, Pairs};
+use pest::Parser as P;
+use pest_derive::Parser;
+
+use crate::document::{CommentFormat, Document, StrFormat};
+use crate::error::Error;
+use crate::integer::{Base, Int};
+
+#[derive(Default, Parser)]
+#[grammar = "relax.pest"]
+pub struct Relax;
+pub(crate) type ParseError = PestError<Rule>;
+
+impl Relax {
+    pub fn from_str(&self, text: &str) -> Result<Document, Error> {
+        let json = Relax::parse(Rule::text, text)?.next().unwrap();
+        self.handle_pair(json)
+    }
+
+    fn handle_number(&self, text: &str) -> Result<Document, Error> {
+        let mut negative = false;
+        let t = if let Some(t) = text.strip_prefix('+') {
+            t
+        } else if let Some(t) = text.strip_prefix('-') {
+            negative = true;
+            t
+        } else {
+            text
+        };
+        if t.starts_with("0x") || t.starts_with("0X") {
+            // Hexadecimal integer.
+            let (_, t) = t.split_at(2);
+            let val = u128::from_str_radix(t, 16).unwrap();
+            if negative {
+                let val = -(val as i128);
+                return Ok(Document::Int(Int::new(val, Base::Hex)));
+            } else {
+                return Ok(Document::Int(Int::new(val, Base::Hex)));
+            }
+        } else if t.contains('.')
+            || t.contains('e')
+            || t.contains('E')
+            || t == "NaN"
+            || t == "Infinity"
+        {
+            // Floating point number.
+            return Ok(Document::Float(text.parse().unwrap()));
+        } else {
+            // Decimal integer.
+            let val = u128::from_str_radix(t, 10).unwrap();
+            if negative {
+                let val = -(val as i128);
+                return Ok(Document::Int(Int::new(val, Base::Dec)));
+            } else {
+                return Ok(Document::Int(Int::new(val, Base::Dec)));
+            }
+        }
+    }
+
+    fn handle_kvpair(&self, pairs: &mut Pairs<Rule>) -> Result<Document, Error> {
+        let mut k = usize::MAX;
+        let mut v = usize::MAX;
+        let mut kv = vec![];
+        loop {
+            let pair = pairs.peek();
+            if pair.is_none() {
+                break;
+            }
+            let pair = pair.unwrap();
+            let (ln, _) = pair.as_span().start_pos().line_col();
+            let node = self.handle_pair(pair)?;
+            let is_comment = node.comment().is_some();
+            if k == usize::MAX || v == usize::MAX {
+                if is_comment {
+                    // Keep
+                } else if k == usize::MAX {
+                    k = ln;
+                } else {
+                    v = ln;
+                }
+            } else if is_comment && v == ln {
+                // Keep
+            } else {
+                // Don't keep - we're done with this kvpair.
+                break;
+            }
+            kv.push(node);
+            // Advance the iterator.
+            let _ = pairs.next();
+        }
+        Ok(Document::Fragment(kv))
+    }
+
+    fn handle_array_elem(&self, pairs: &mut Pairs<Rule>) -> Result<Document, Error> {
+        let mut i = usize::MAX;
+        let mut item = vec![];
+        loop {
+            let pair = pairs.peek();
+            if pair.is_none() {
+                break;
+            }
+            let pair = pair.unwrap();
+            let (ln, _) = pair.as_span().start_pos().line_col();
+            let node = self.handle_pair(pair)?;
+            let is_comment = node.comment().is_some();
+            if i == usize::MAX {
+                if is_comment {
+                    // Keep
+                } else {
+                    i = ln;
+                }
+            } else if is_comment && i == ln {
+                // Keep
+            } else {
+                // Don't keep - we're done with this kvpair.
+                break;
+            }
+            item.push(node);
+            // Advance the iterator.
+            let _ = pairs.next();
+        }
+        if item.len() == 1 && item[0].comment().is_none() {
+            Ok(item.pop().unwrap())
+        } else {
+            Ok(Document::Fragment(item))
+        }
+    }
+
+    fn strip_leading_prefix<'a>(lines: &[&'a str], prefix: char) -> Vec<&'a str> {
+        let plen = lines.iter().fold(usize::MAX, |acc, s| {
+            if s.is_empty() {
+                acc
+            } else {
+                let plen = s.len() - s.trim_start_matches(prefix).len();
+                std::cmp::min(acc, plen)
+            }
+        });
+        lines
+            .iter()
+            .map(|s| if s.is_empty() { s } else { s.split_at(plen).1 })
+            .collect::<Vec<_>>()
+    }
+
+    fn handle_comment(&self, pair: Pair<Rule>) -> Result<Document, Error> {
+        let comment = pair.as_str();
+        if let Some(c) = comment.strip_prefix("/*") {
+            let c = c.strip_suffix("*/").unwrap().trim_end();
+            let lines = c.split("\n").map(str::trim).collect::<Vec<_>>();
+            let lines = Self::strip_leading_prefix(&lines, '*');
+            let lines = Self::strip_leading_prefix(&lines, ' ');
+            let start = if lines.get(0).map(|s| s.is_empty()) == Some(true) {
+                1
+            } else {
+                0
+            };
+            let c = lines[start..].join("\n");
+            Ok(Document::Comment(c, CommentFormat::Normal))
+        } else if comment.starts_with("//") {
+            let lines = comment.split("\n").map(str::trim).collect::<Vec<_>>();
+            let lines = Self::strip_leading_prefix(&lines, '/');
+            let lines = Self::strip_leading_prefix(&lines, ' ');
+            let end = lines.len()
+                - if lines.last().map(|s| s.is_empty()) == Some(true) {
+                    1
+                } else {
+                    0
+                };
+            let c = lines[..end].join("\n");
+            Ok(Document::Comment(c, CommentFormat::Normal))
+        } else {
+            Err(Error::Unknown(comment.into()))
+        }
+    }
+
+    fn handle_pair(&self, pair: Pair<Rule>) -> Result<Document, Error> {
+        match pair.as_rule() {
+            //Rule::value => self.handle_pair(pair.into_inner().next().unwrap()),
+            Rule::null => Ok(Document::Null),
+            Rule::boolean => Ok(Document::Boolean(pair.as_str().parse().unwrap())),
+            Rule::string => {
+                let s = pair.as_str();
+                let end = s.len() - 1;
+                Ok(Document::String(s[1..end].into(), StrFormat::Standard))
+            }
+            Rule::identifier => {
+                // TODO: add StrFormat::Unquoted
+                Ok(Document::String(pair.as_str().into(), StrFormat::Standard))
+            }
+            Rule::number => self.handle_number(pair.as_str()),
+            Rule::object => {
+                let mut pairs = pair.into_inner();
+                let mut kvs = Vec::new();
+                while pairs.peek().is_some() {
+                    kvs.push(self.handle_kvpair(&mut pairs)?);
+                }
+                Ok(Document::Mapping(kvs))
+            }
+            Rule::array => {
+                let mut pairs = pair.into_inner();
+                let mut values = Vec::new();
+                while pairs.peek().is_some() {
+                    values.push(self.handle_array_elem(&mut pairs)?);
+                }
+                Ok(Document::Sequence(values))
+            }
+            Rule::COMMENT => self.handle_comment(pair),
+            Rule::EOI => Ok(Document::Null),
+            Rule::text => {
+                let mut doc = pair
+                    .into_inner()
+                    .map(|p| self.handle_pair(p))
+                    .collect::<Result<Vec<_>, _>>()?;
+                // Since we explicitly handled EOI, remove the dummy Null node
+                // from the end of the vector.
+                let _ = doc.pop();
+                // A single node, or a sequence?
+                if doc.len() == 1 {
+                    Ok(doc.pop().unwrap())
+                } else {
+                    Ok(Document::Fragment(doc))
+                }
+            }
+
+            _ => Err(Error::Unknown(format!("{:?}", pair)).into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{anyhow, Result};
+
+    #[test]
+    fn test_null() -> Result<()> {
+        let relax = Relax::default();
+        let null = relax.from_str("null")?;
+        assert!(matches!(null, Document::Null));
+        Ok(())
+    }
+
+    #[test]
+    fn test_boolean() -> Result<()> {
+        let relax = Relax::default();
+        let b = relax.from_str("true")?;
+        assert!(matches!(b, Document::Boolean(true)));
+        let b = relax.from_str("false")?;
+        assert!(matches!(b, Document::Boolean(false)));
+        Ok(())
+    }
+
+    fn parse_string(r: &Relax, text: &str) -> Result<String> {
+        if let Document::String(s, _) = r.from_str(text)? {
+            Ok(s)
+        } else {
+            Err(anyhow!("Didn't return Document::String()"))
+        }
+    }
+
+    #[test]
+    fn test_string() -> Result<()> {
+        let relax = Relax::default();
+        let s = parse_string(&relax, r#""foo""#)?;
+        assert_eq!(s, "foo");
+        Ok(())
+    }
+
+    fn parse_integer(r: &Relax, text: &str) -> Result<i128> {
+        if let Document::Int(int) = r.from_str(text)? {
+            Ok(int.into())
+        } else {
+            Err(anyhow!("Didn't return Document::Int()"))
+        }
+    }
+
+    fn parse_float(r: &Relax, text: &str) -> Result<f64> {
+        if let Document::Float(f) = r.from_str(text)? {
+            Ok(f)
+        } else {
+            Err(anyhow!("Didn't return Document::Float()"))
+        }
+    }
+
+    #[test]
+    fn test_number_hex() -> Result<()> {
+        let relax = Relax::default();
+        let i = parse_integer(&relax, "0x1234")?;
+        assert_eq!(i, 0x1234);
+        let i = parse_integer(&relax, "-0x5678")?;
+        assert_eq!(i, -0x5678);
+        Ok(())
+    }
+
+    #[test]
+    fn test_number_dec() -> Result<()> {
+        let relax = Relax::default();
+        let i = parse_integer(&relax, "+1234")?;
+        assert_eq!(i, 1234);
+        let i = parse_integer(&relax, "-5678")?;
+        assert_eq!(i, -5678);
+        Ok(())
+    }
+
+    #[test]
+    fn test_number_float() -> Result<()> {
+        let relax = Relax::default();
+        let f = parse_float(&relax, "+1234.56")?;
+        assert_eq!(f, 1234.56);
+        let f = parse_float(&relax, "-5e6")?;
+        assert_eq!(f, -5e6);
+        let f = parse_float(&relax, "Infinity")?;
+        assert_eq!(f, f64::INFINITY);
+        Ok(())
+    }
+
+    fn parse_mapping(r: &Relax, text: &str) -> Result<Vec<Document>> {
+        if let Document::Mapping(m) = r.from_str(text)? {
+            Ok(m)
+        } else {
+            Err(anyhow!("Didn't return Document::Mapping()"))
+        }
+    }
+
+    fn kv_extract<'a>(kv: Option<&'a Document>) -> Result<(&'a str, &'a str)> {
+        if let Some((Document::String(k, _), Document::String(v, _))) =
+            kv.map(Document::as_kv).transpose()?
+        {
+            Ok((k.as_str(), v.as_str()))
+        } else {
+            Err(anyhow!("Expected KeyValue(String, String), not {:?}", kv))
+        }
+    }
+
+    #[test]
+    fn test_mapping() -> Result<()> {
+        let relax = Relax::default();
+        let mapping = parse_mapping(&relax, r#"{"foo": "bar", baz: "boo"}"#)?;
+        let mut m = mapping.iter();
+        let (k, v) = kv_extract(m.next())?;
+        assert_eq!(k, "foo");
+        assert_eq!(v, "bar");
+        let (k, v) = kv_extract(m.next())?;
+        assert_eq!(k, "baz");
+        assert_eq!(v, "boo");
+        assert!(m.next().is_none());
+        Ok(())
+    }
+
+    fn parse_sequence(r: &Relax, text: &str) -> Result<Vec<Document>> {
+        if let Document::Sequence(s) = r.from_str(text)? {
+            Ok(s)
+        } else {
+            Err(anyhow!("Didn't return Document::Mapping()"))
+        }
+    }
+
+    #[test]
+    fn test_sequence() -> Result<()> {
+        let relax = Relax::default();
+        let sequence = parse_sequence(&relax, "[true, false, 3.14159]")?;
+        let mut s = sequence.iter();
+        assert!(matches!(s.next(), Some(Document::Boolean(true))));
+        assert!(matches!(s.next(), Some(Document::Boolean(false))));
+        assert!(matches!(s.next(), Some(Document::Float(3.14159))));
+        assert!(s.next().is_none());
+        Ok(())
+    }
+
+    fn parse_comment(r: &Relax, text: &str) -> Result<(String, CommentFormat)> {
+        if let Document::Comment(c, f) = r.from_str(text)? {
+            Ok((c, f))
+        } else {
+            Err(anyhow!("Didn't return Document::Mapping()"))
+        }
+    }
+    #[test]
+    fn test_comment() -> Result<()> {
+        let relax = Relax::default();
+        let sequence = parse_sequence(
+            &relax,
+            r#"[
+            // Some true value
+            // extended
+            // with more
+            true,
+            // A false value
+            false,
+            /*
+             * Yet another value
+             * but with a block
+             * comment this time.
+             */
+            false
+        ]"#,
+        )?;
+        match &sequence[..] {
+            [Document::Fragment(a), Document::Fragment(b), Document::Fragment(c)] => {
+                let mut i = a.iter();
+                assert!(matches!(i.next(), Some(Document::Comment(_, _))));
+                assert!(matches!(i.next(), Some(Document::Boolean(true))));
+                assert!(i.next().is_none());
+                let mut i = b.iter();
+                assert!(matches!(i.next(), Some(Document::Comment(_, _))));
+                assert!(matches!(i.next(), Some(Document::Boolean(false))));
+                assert!(i.next().is_none());
+                let mut i = c.iter();
+                assert!(matches!(i.next(), Some(Document::Comment(_, _))));
+                assert!(matches!(i.next(), Some(Document::Boolean(false))));
+                assert!(i.next().is_none());
+            }
+            _ => return Err(anyhow!("Unexpected structure")),
+        };
+
+        let mapping = parse_mapping(
+            &relax,
+            r#"{
+          // quoted
+          "foo": "bar",
+          baz: "boo" // bareword
+        }"#,
+        )?;
+        match &mapping[..] {
+            [Document::Fragment(a), Document::Fragment(b)] => {
+                let mut i = a.iter();
+                assert!(matches!(i.next(), Some(Document::Comment(_, _))));
+                assert!(matches!(i.next(), Some(Document::String(_, _))));
+                assert!(matches!(i.next(), Some(Document::String(_, _))));
+                assert!(i.next().is_none());
+                let mut i = b.iter();
+                assert!(matches!(i.next(), Some(Document::String(_, _))));
+                assert!(matches!(i.next(), Some(Document::String(_, _))));
+                assert!(matches!(i.next(), Some(Document::Comment(_, _))));
+                assert!(i.next().is_none());
+            }
+            _ => return Err(anyhow!("Unexpected structure")),
+        };
+        Ok(())
+    }
+}

--- a/src/relax.rs
+++ b/src/relax.rs
@@ -274,12 +274,7 @@ impl Relax {
         let mut v = usize::MAX;
         let mut kv = vec![];
         let mut comma = false;
-        loop {
-            let pair = pairs.peek();
-            if pair.is_none() {
-                break;
-            }
-            let pair = pair.unwrap();
+        while let Some(pair) = pairs.peek() {
             let rule = pair.as_rule();
             if rule == Rule::comma {
                 comma = true;
@@ -329,12 +324,7 @@ impl Relax {
         let mut item = vec![];
         let mut comma = false;
         let mut saw_value = false;
-        loop {
-            let pair = pairs.peek();
-            if pair.is_none() {
-                break;
-            }
-            let pair = pair.unwrap();
+        while let Some(pair) = pairs.peek() {
             let rule = pair.as_rule();
             if rule == Rule::comma {
                 let _ = pairs.next();
@@ -522,7 +512,6 @@ impl Relax {
 
     fn handle_pair(&self, pair: Pair<Rule>) -> Result<Document, Error> {
         match pair.as_rule() {
-            //Rule::value => self.handle_pair(pair.into_inner().next().unwrap()),
             Rule::null => Ok(Document::Null),
             Rule::boolean => Ok(Document::Boolean(pair.as_str().parse().unwrap())),
             Rule::string => self.handle_string(pair),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -66,7 +66,7 @@ impl<'a> AnnotatedSerializer<'a> {
         self.annotator
             .map(|a| a.comment(variant, field))
             .flatten()
-            .map(|c| Document::Comment(c, CommentFormat::Normal))
+            .map(|c| Document::Comment(c, CommentFormat::Standard))
     }
 
     fn serialize<T>(&self, value: &T, ser: Option<AnnotatedSerializer>) -> Result<Document, Error>

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -328,7 +328,9 @@ impl YamlEmitter {
         match f {
             StrFormat::Multiline => self.emit_string_multiline(w, value)?,
             StrFormat::Quoted => self.escape_str(w, value, true)?,
-            StrFormat::Standard => self.escape_str(w, value, need_quotes(value))?,
+            StrFormat::Unquoted | StrFormat::Standard => {
+                self.escape_str(w, value, need_quotes(value))?
+            }
         }
         Ok(())
     }
@@ -560,6 +562,8 @@ fn need_quotes(string: &str) -> bool {
         .contains(&string)
         || string.starts_with('.')
         || string.starts_with("0x")
+        || string.starts_with("0b")
+        || string.starts_with("0o")
         || string.parse::<i64>().is_ok()
         || string.parse::<f64>().is_ok()
 }
@@ -592,7 +596,7 @@ mod tests {
         Document::String(v.to_string(), StrFormat::Multiline)
     }
     fn comment(v: &str) -> Document {
-        Document::Comment(v.to_string(), CommentFormat::Normal)
+        Document::Comment(v.to_string(), CommentFormat::Standard)
     }
     fn kv(k: &str, v: Document) -> Document {
         Document::Fragment(vec![string(k), v])

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -207,7 +207,7 @@ impl YamlEmitter {
             skip = false;
         }
         if self.compact || mapping.is_empty() {
-            write!(w, "{}", self.color.aggregate.paint(")"))?;
+            write!(w, "{}", self.color.aggregate.paint("}"))?;
         } else {
             self.level -= 1;
         }


### PR DESCRIPTION
This series of commits adds a json parser to the serde-annotate libary.  The parser uses a PEG-style grammar via the `pest` crate (starting from the pest grammar in the `json5` crate).  The parser defaults to a maximally permissive mode, but can be customized to forbid certain json extensions.

The maximally permissive parser allows:
- Comments in the 3 common styles (C-like block comments, C++-like slash-slash comments and script-like hash comments).
- Commas in aggregates are optional (hjson-like).
- Aggregates may have a trailing comma (json5-like).
- Integers are permitted in the common bases using the common prefixes (`0b`, `0o`, `0x`).
- Json5 numeric extensions are supported (being lax with decimal-point placement).
- Multiline string blocks are permitted in hjson (triple-quote) and json5 (C-like line continuation) style.
- Unquoted strings are supported in both json5 and hjson style.

This PR adds support for parsing json-like text into a `Document` strucure.