### PR TITLE
Support type-erased serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ annotate_derive = {path = "annotate_derive"}
 inventory = "0.2"
 pest = "2.2"
 pest_derive = "2.2"
+#erased-serde = "0.3"
+erased-serde = { git = "https://github.com/cfrantz/erased-serde", branch = "feature-type-name" }
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -25,3 +27,7 @@ deser-hjson = "1.0.2"
 serde_bytes = "0.11"
 serde_yaml = "0.8.24"
 clap = { version="3.2.8", features=["derive"] }
+
+[features]
+type_by_name = []
+erased = ["type_by_name", "erased-serde/type_name"]

--- a/annotate_derive/src/expand.rs
+++ b/annotate_derive/src/expand.rs
@@ -119,7 +119,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         const _: () = {
             extern crate serde_annotate;
             extern crate inventory;
-            use serde_annotate::annotate::{Annotate, AnnotateType, Format, MemberId};
+            use serde_annotate::annotate::{Annotate, AnnotateType, Format, IdType, MemberId};
 
             impl Annotate for #name {
                 fn format(&self, _variant: Option<&str>, field: &MemberId) -> Option<Format> {
@@ -136,7 +136,7 @@ fn impl_struct(input: Struct) -> TokenStream {
                 }
             }
             impl #name {
-                fn __type_id() -> usize {
+                fn __type_id() -> IdType {
                     AnnotateType::type_id::<Self>()
                 }
                 unsafe fn __cast(ptr: *const ()) -> &'static dyn Annotate {
@@ -161,7 +161,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         const _: () = {
             extern crate serde_annotate;
             extern crate inventory;
-            use serde_annotate::annotate::{Annotate, AnnotateType, Format, MemberId};
+            use serde_annotate::annotate::{Annotate, AnnotateType, Format, IdType, MemberId};
 
             impl Annotate for #name {
                 fn format(&self, variant: Option<&str>, field: &MemberId) -> Option<Format> {
@@ -180,7 +180,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                 }
             }
             impl #name {
-                fn __type_id() -> usize {
+                fn __type_id() -> IdType {
                     AnnotateType::type_id::<Self>()
                 }
                 unsafe fn __cast(ptr: *const ()) -> &'static dyn Annotate {

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -33,7 +33,12 @@ pub trait Annotate {
     fn comment(&self, variant: Option<&str>, field: &MemberId) -> Option<String>;
 }
 
-type IdFn = fn() -> usize;
+#[cfg(not(feature = "type_by_name"))]
+pub type IdType = usize;
+#[cfg(feature = "type_by_name")]
+pub type IdType = &'static str;
+
+type IdFn = fn() -> IdType;
 type CastFn = unsafe fn(*const ()) -> &'static dyn Annotate;
 
 pub struct AnnotateType {
@@ -43,17 +48,40 @@ pub struct AnnotateType {
 inventory::collect!(AnnotateType);
 
 impl AnnotateType {
-    pub fn type_id<T>() -> usize
+    #[cfg(not(feature = "type_by_name"))]
+    pub fn type_id<T>() -> IdType
     where
         T: ?Sized,
     {
+        // We can't use std::any::TypeId here because we don't want to
+        // limit T to 'static.
+        //
         // Just like https://github.com/rust-lang/rust/issues/41875#issuecomment-317292888
         // We monomorphize on T and then cast the function pointer address of
         // the monomorphized `AnnotateType::type_id` function to an
         // integer identifier.
+        //
+        // This can't be relied upon because the compiler might optimize this away.
+        // In practice, it seems to work.
         Self::type_id::<T> as usize
     }
 
+    #[cfg(feature = "type_by_name")]
+    pub fn type_id<T>() -> IdType
+    where
+        T: ?Sized,
+    {
+        // Instead of using the hacky "type_id" monomorphization trick, we use
+        // the type name given back by the standard library.
+        //
+        // This can't be relied upon because the standard library makes no
+        // guarantees about the returned string. In practice, it seems to work.
+        std::any::type_name::<T>()
+    }
+
+    // This is unsafe because we give the returned trait object
+    // a 'static lifetime.  We use transmute later to shorten the
+    // lifetime down to the known lifetime.
     pub unsafe fn cast<T>(ptr: *const ()) -> &'static dyn Annotate
     where
         T: 'static + Annotate,
@@ -63,8 +91,8 @@ impl AnnotateType {
         &*(ptr as *const T)
     }
 
-    fn lookup(id: usize) -> Option<CastFn> {
-        static TYPEMAP: OnceCell<Mutex<HashMap<usize, CastFn>>> = OnceCell::new();
+    fn lookup(id: IdType) -> Option<CastFn> {
+        static TYPEMAP: OnceCell<Mutex<HashMap<IdType, CastFn>>> = OnceCell::new();
         let typemap = TYPEMAP
             .get_or_init(|| {
                 let mut types = HashMap::new();
@@ -78,15 +106,32 @@ impl AnnotateType {
         typemap.get(&id).cloned()
     }
 
+    #[cfg(not(feature = "erased"))]
     pub fn get<'a, T>(object: &'a T) -> Option<&'a dyn Annotate>
     where
-        T: ?Sized,
+        T: ?Sized + serde::Serialize,
     {
-        // Get the type-id of `object` can cast it to `Annotate` if we can.
+        // Get the type-id of `object` and cast it to `Annotate` if we can.
         let id = Self::type_id::<T>();
         Self::lookup(id).map(|cast| unsafe {
             // Shorten the lifetime to 'a, as the dyn Annotate reference is
-            // really a reinterpretation of `object`, which has lifetime 'a.
+            // really a fat pointer to `object`, which has lifetime 'a.
+            std::mem::transmute::<&'static dyn Annotate, &'a dyn Annotate>(cast(
+                object as *const T as *const (),
+            ))
+        })
+    }
+
+    #[cfg(feature = "erased")]
+    pub fn get<'a, T>(object: &'a T) -> Option<&'a dyn Annotate>
+    where
+        T: ?Sized + erased_serde::Serialize,
+    {
+        // Get the type-id of `object` and cast it to `Annotate` if we can.
+        let id = object.type_name();
+        Self::lookup(id).map(|cast| unsafe {
+            // Shorten the lifetime to 'a, as the dyn Annotate reference is
+            // really a fat pointer to `object`, which has lifetime 'a.
             std::mem::transmute::<&'static dyn Annotate, &'a dyn Annotate>(cast(
                 object as *const T as *const (),
             ))


### PR DESCRIPTION
I'd originally planned to add this support with the nightly feature `min_specialization`, but (a) that wont work for a couple of reasons (detailed below) and (b) that feature has been open for ~6 years and doesn't seem to be moving.

### `min_specialization` won't work
- It appears that `feature(min_specialization)` won't work across crate boundaries.  I'd planned to provide a blanket implementation of `Annotate` for `T` where `T: serde::Serialize` and then have the annotate-derive macro provide specialized impls per annotated type.  However, since the proc-macro generated code is outside of the serde-annotate crate, that won't work.
- It _also_ seems that one cannot specialize on traits with associated types and serde::Serialize has several.

### `negative_impls` won't work
My next plan was to try to use `feature(negative_impls)` to create a marker trait that could apply to `serde::Serialize` and not to `erased_serde::Serialize` (or vice-versa).  However, when you're using erased-serde, _every_ type that is `serde::Serialize` is _also_ `erased_serde::Serialize`.

### `std::any::TypeId / Any` won't work
This is already known from the pre-erased-serde implementation, but it bears repeating:  The serde library does not restrict itself to `'static` types, so the standard way of getting a type-id or casting between types won't work.

### The monomorphized function pointer trick won't work
Pre-erased-serde, I was using a monomorphized function pointer to get a unique type-id per type.  While this trick generally works, it isn't guaranteed to work (optimization could eliminate all of the like monomorphized functions).  However, I couldn't seem to get the type-id of the bare type out of `erased_serde::Serialized` -- I was always getting reference-to the type.  The `_of_val` trick didn't seem to work either (I was _always_ getting the type-id of &T, not T):
```
fn type_id_of_val<T>(val: &T) {
  type_id::<T>();
}
```
### Using the type by name
Ultimately, I settled on querying the type-name using `std::any::type_name` and eliminating references from the returned string.  I'm not satisfied with this approach, but I don't know what else to do without further investigation.  The only advantage to this trick is that no nightly features are required.

Signed-off-by: Chris Frantz <cfrantz@google.com>